### PR TITLE
Cache the VTune installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ environments are highly limited and certain knobs are not available.
 
 ### Parameters
 
-| Input     | Default  | Description                                              |
-|-----------|----------|----------------------------------------------------------|
-| `env`     | true     | Run the VTune setup script to configure the environment. |
+| Input     | Default          | Description                                              |
+|-----------|------------------|----------------------------------------------------------|
+| `url`     | See [action.yml] | The location of an VTune installation script.            |
+| `sha384`  | See [action.yml] | The SHA-384 hash of the VTune installation script        |
+| `env`     | true             | Run the VTune setup script to configure the environment. |
+
+[action.yml]: ./action.yml

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,16 @@
 name: 'Install VTune'
 description: 'Install the VTune binaries on a GitHub runner'
 
-# See https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
+# The Intel VTune download site has instructions (below the fold) for downloading an "offline
+# installer" script as well as its SHA384 checksum. To update the default version of VTune, navigate
+# to:
+# https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler-download.html?operatingsystem=linux&distributions=offline.
 inputs:
   url:
-    description: 'The location of an offline VTune installation script'
+    description: 'The location of the VTune installation script'
     default: 'https://registrationcenter-download.intel.com/akdlm/IRC_NAS/dfae6f23-6c90-4b9f-80e2-fa2a5037fe36/l_oneapi_vtune_p_2023.2.0.49485_offline.sh'
   sha384:
-    description: 'The SHA-384 hash of the offline VTune installation script'
+    description: 'The SHA-384 hash of the VTune installation script'
     default: '43431383783e8a204f67f5f6719f74becb8e3c97862661b20b56c2c5d87c529d103a1493779565b4bbb3f372092c1b6b'
   env:
     description: 'Run the VTune setup script to configure the runner environment'

--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,14 @@ description: 'Install the VTune binaries on a GitHub runner'
 
 # See https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
 inputs:
+  url:
+    description: 'The location of an offline VTune installation script'
+    default: 'https://registrationcenter-download.intel.com/akdlm/IRC_NAS/dfae6f23-6c90-4b9f-80e2-fa2a5037fe36/l_oneapi_vtune_p_2023.2.0.49485_offline.sh'
+  sha384:
+    description: 'The SHA-384 hash of the offline VTune installation script'
+    default: '43431383783e8a204f67f5f6719f74becb8e3c97862661b20b56c2c5d87c529d103a1493779565b4bbb3f372092c1b6b'
   env:
-    description: 'Run the VTune setup script to configure the environment'
+    description: 'Run the VTune setup script to configure the runner environment'
     default: true
 
 runs:
@@ -18,26 +24,24 @@ runs:
     working-directory: ${{ github.action_path }}
     if: ${{ !startsWith(runner.os, 'linux') }}
 
-  # Cache the entire VTune installation directory.
+  # Cache the entire VTune installation directory; use a prefix of the SHA-384 hash to make the
+  # cache key unique.
+  - name: Calculate cache ID
+    run: echo VTUNE_ID=$(echo "${{ inputs.sha384 }}" | cut -c1-7) >> $GITHUB_ENV
+    shell: bash
   - name: Cache artifacts
     id: cache-vtune-installation
     uses: actions/cache@v3
     with:
       path: /home/runner/intel/oneapi
-      key: vtune
+      key: vtune-${{ env.VTUNE_ID }}
 
-  # Install on cache miss.
+  # Download and install only on cache miss.
   - if: ${{ steps.cache-vtune-installation.outputs.cache-hit != 'true' }}
     name: Install
-    run: ./install.sh
+    run: ./install.sh ${{ inputs.url }} ${{ inputs.sha384 }}
     shell: bash
     working-directory: ${{ github.action_path }}
-
-  - name: Debug...
-    run: |
-      echo $HOME
-      ls -al $HOME/intel/oneapi
-    shell: bash
 
   # Configure the GitHub runner.
   - name: Setup environment

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     shell: bash
     working-directory: ${{ github.action_path }}
 
-  - name: Debug
+  - name: Debug...
     run: |
       echo $HOME
       ls -al $HOME/intel/oneapi

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,12 @@ runs:
     shell: bash
     working-directory: ${{ github.action_path }}
 
+  - name: Debug
+    run: |
+      echo $HOME
+      echo $HOME/intel/oneapi
+    shell: bash
+
   # Configure the GitHub runner.
   - name: Setup environment
     run: |

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
     id: cache-vtune-installation
     uses: actions/cache@v3
     with:
-      path: ${{ env.HOME }}/intel/oneapi
+      path: /home/runner/intel/oneapi
       key: vtune
 
   # Install on cache miss.
@@ -36,7 +36,7 @@ runs:
   - name: Debug
     run: |
       echo $HOME
-      echo $HOME/intel/oneapi
+      ls -al $HOME/intel/oneapi
     shell: bash
 
   # Configure the GitHub runner.

--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,23 @@ runs:
     shell: bash
     working-directory: ${{ github.action_path }}
     if: ${{ !startsWith(runner.os, 'linux') }}
-  - name: Install
+
+  # Cache the entire VTune installation directory.
+  - name: Cache artifacts
+    id: cache-vtune-installation
+    uses: actions/cache@v3
+    with:
+      path: ${{ env.HOME }}/intel/oneapi
+      key: vtune
+
+  # Install on cache miss.
+  - if: ${{ steps.cache-vtune-installation.outputs.cache-hit != 'true' }}
+    name: Install
     run: ./install.sh
     shell: bash
     working-directory: ${{ github.action_path }}
-    if: ${{ startsWith(runner.os, 'linux') }}
+
+  # Configure the GitHub runner.
   - name: Setup environment
     run: |
       source $HOME/intel/oneapi/setvars.sh

--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,16 @@ set -e
 # Install VTune on Linux from the offline script. See
 # https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler-download.html?operatingsystem=linux&distributions=offline.
 
-script="l_oneapi_vtune_p_2023.2.0.49485_offline.sh"
-url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/dfae6f23-6c90-4b9f-80e2-fa2a5037fe36/${script}"
-sha384="43431383783e8a204f67f5f6719f74becb8e3c97862661b20b56c2c5d87c529d103a1493779565b4bbb3f372092c1b6b"
+if [[ $# -ne 2 ]] ; then
+    echo 'incorrect number of parameters; usage: install.sh <url> <sha384>'
+    exit 1
+fi
+url="$1"
+sha384="$2"
+script=$(basename $url)
 
 # Determine the directory of this script.
-action_dir="$(dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd ))"
+action_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Set up the checksum provided at the intel.com site.
 echo "${sha384} ${action_dir}/${script}" > $action_dir/CHECKSUM
@@ -20,4 +24,4 @@ set -x
 # Download, check, and install.
 wget --no-verbose --directory-prefix=$action_dir $url
 sha384sum --check $action_dir/CHECKSUM
-sh $action_dir/l_oneapi_vtune_p_2023.2.0.49485_offline.sh -a --silent --eula accept
+sh $action_dir/$script -a --silent --eula accept

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-# Install VTune on Linux from the offline script. See
-# https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler-download.html?operatingsystem=linux&distributions=offline.
+# Download and install VTune on Linux using the URL to an offline installer script. See `action.yml`
+# for how to retrieve the URL and SHA384 checksum.
+#
+# Usage: install.sh <url> <sha384>
 
 if [[ $# -ne 2 ]] ; then
     echo 'incorrect number of parameters; usage: install.sh <url> <sha384>'


### PR DESCRIPTION
Unlike the attempt in PR #3, this change caches all the installed files after the VTune installer has run (`$HOME/intel/oneapi`). Even though the cache will be larger, this will likely reduce the installation time significantly; PR #3 clocks in around 1 minute and 20 seconds.

For later reference:
 - caching the entire installation: ~640MB, 20 seconds
 - caching just the installer script: ~575MB, 80 seconds